### PR TITLE
Add email address to DNS changes to allow auto-CR creation

### DIFF
--- a/main.go
+++ b/main.go
@@ -124,7 +124,7 @@ func getCurrentCNAME(c *conf, domain string) (string, error) {
 }
 
 func createDNS(c *conf, elbCNAME string, domain string) error {
-	body := fmt.Sprintf("{\"zone\": \"ft.com\", \"name\": \"%s\",\"rdata\": \"%s\",\"ttl\": \"30\"}", domain, elbCNAME)
+	body := fmt.Sprintf("{\"zone\": \"ft.com\", \"name\": \"%s\",\"rdata\": \"%s\",\"ttl\": \"30\",\"emailAddress\": \"euan.finlay@ft.com\"}", domain, elbCNAME)
 	req, err := http.NewRequest(http.MethodPost, c.konsDNSEndPoint, strings.NewReader(body))
 	if err != nil {
 		return err
@@ -136,7 +136,7 @@ func createDNS(c *conf, elbCNAME string, domain string) error {
 }
 
 func updateDNS(c *conf, oldCname string, newCname, domain string) error {
-	body := fmt.Sprintf("{\"zone\": \"ft.com\", \"name\": \"%s\",\"oldRdata\": \"%s\",\"newRdata\": \"%s\",\"ttl\": \"30\"}", domain, oldCname, newCname)
+	body := fmt.Sprintf("{\"zone\": \"ft.com\", \"name\": \"%s\",\"oldRdata\": \"%s\",\"newRdata\": \"%s\",\"ttl\": \"30\",\"emailAddress\": \"euan.finlay@ft.com\"}", domain, oldCname, newCname)
 	req, err := http.NewRequest(http.MethodPut, c.konsDNSEndPoint, strings.NewReader(body))
 	if err != nil {
 		return err


### PR DESCRIPTION
Automatically raise CRs when deleting DNS records via Konstructor.

Currently uses my own email address due to limitations in Salesforce - have requested a service account to be set up so that we can use a group email instead, but that might take a week or longer.
